### PR TITLE
Linux compatibility for examples and ctrl c escape issue

### DIFF
--- a/examples/custom_bindings/Cargo.toml
+++ b/examples/custom_bindings/Cargo.toml
@@ -18,3 +18,8 @@ egui_term = { path = "../../" }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11"
+
+[features]
+default = []
+x11 = ["eframe/x11"]
+wayland = ["eframe/wayland"]

--- a/examples/fonts/Cargo.toml
+++ b/examples/fonts/Cargo.toml
@@ -17,3 +17,8 @@ egui_term = { path = "../../" }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11"
+
+[features]
+default = []
+x11 = ["eframe/x11"]
+wayland = ["eframe/wayland"]

--- a/examples/full_screen/Cargo.toml
+++ b/examples/full_screen/Cargo.toml
@@ -17,3 +17,8 @@ egui_term = { path = "../../" }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11"
+
+[features]
+default = []
+x11 = ["eframe/x11"]
+wayland = ["eframe/wayland"]

--- a/examples/split_view/Cargo.toml
+++ b/examples/split_view/Cargo.toml
@@ -19,3 +19,8 @@ winit = "0.30"
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11"
+
+[features]
+default = []
+x11 = ["eframe/x11"]
+wayland = ["eframe/wayland"]

--- a/examples/tabs/Cargo.toml
+++ b/examples/tabs/Cargo.toml
@@ -17,3 +17,8 @@ egui_term = { path = "../../" }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11.6"
+
+[features]
+default = []
+x11 = ["eframe/x11"]
+wayland = ["eframe/wayland"]

--- a/examples/themes/Cargo.toml
+++ b/examples/themes/Cargo.toml
@@ -17,3 +17,8 @@ egui_term = { path = "../../" }
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11.6"
+
+[features]
+default = []
+x11 = ["eframe/x11"]
+wayland = ["eframe/wayland"]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -243,6 +243,10 @@ impl TerminalBackend {
         viewport_to_point(display_offset, Point::new(line, col))
     }
 
+    pub fn is_selected_mode(&self) -> bool {
+        self.last_content().selectable_range.is_some()
+    }
+
     pub fn selectable_content(&self) -> String {
         let content = self.last_content();
         let mut result = String::new();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -243,10 +243,6 @@ impl TerminalBackend {
         viewport_to_point(display_offset, Point::new(line, col))
     }
 
-    pub fn is_selected_mode(&self) -> bool {
-        self.last_content().selectable_range.is_some()
-    }
-
     pub fn selectable_content(&self) -> String {
         let content = self.last_content();
         let mut result = String::new();

--- a/src/view.rs
+++ b/src/view.rs
@@ -363,7 +363,7 @@ fn process_keyboard_event(
         ),
         egui::Event::Copy => {
             #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-            if backend.is_selected_mode() {
+            if modifiers.contains(Modifiers::COMMAND | Modifiers::SHIFT) {
                 let content = backend.selectable_content();
                 InputAction::WriteToClipboard(content)
             } else {

--- a/src/view.rs
+++ b/src/view.rs
@@ -359,7 +359,17 @@ fn process_keyboard_event(
             process_text_event(&text, modifiers, backend, bindings_layout)
         },
         egui::Event::Paste(text) => InputAction::BackendCall(
-            BackendCommand::Write(text.as_bytes().to_vec()),
+            #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+            if modifiers.contains(Modifiers::COMMAND | Modifiers::SHIFT) {
+                BackendCommand::Write(text.as_bytes().to_vec())
+            } else {
+                // Hotfix - Send ^V when there's not selection on view.
+                BackendCommand::Write([0x16].to_vec())
+            },
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            {
+                BackendCommand::Write(text.as_bytes().to_vec())
+            },
         ),
         egui::Event::Copy => {
             #[cfg(not(any(target_os = "ios", target_os = "macos")))]

--- a/src/view.rs
+++ b/src/view.rs
@@ -362,8 +362,19 @@ fn process_keyboard_event(
             BackendCommand::Write(text.as_bytes().to_vec()),
         ),
         egui::Event::Copy => {
-            let content = backend.selectable_content();
-            InputAction::WriteToClipboard(content)
+            #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+            if backend.is_selected_mode() {
+                let content = backend.selectable_content();
+                InputAction::WriteToClipboard(content)
+            } else {
+                // Hotfix - Send ^C when there's not selection on view.
+                InputAction::BackendCall(BackendCommand::Write([0x3].to_vec()))
+            }
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            {
+                let content = backend.selectable_content();
+                InputAction::WriteToClipboard(content)
+            }
         },
         egui::Event::Key {
             key,


### PR DESCRIPTION
I propose a PR because I found some issues while making a hardware serial terminal using `egui_term`. ( https://github.com/pmnxis/egui_term/tree/serial-tty-rename-proposal )

There was a problem that Escape could not be sent when Ctrl+C was entered on Windows and Linux. I identified this as a problem caused by `egui::Event` not being able to anticipate this situation, and I added a feature to examples considering that the eframe (related to winit) feature flag is required in the x11/wayland environment of Linux.

---------
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/32729bd7-0206-4fbc-97ae-25f3f3b46012" />

I would like to fork the project under the name "egui_serial_term", while maintaining the original license and crediting the original author. Would this be acceptable?

Initially, I attempted to keep the serial TTY backend instead of using a PTY. While this approach worked well on Linux, it encountered issues on Windows and certain macOS hardware. As a result, modifications to both the backend and event loop became necessary. Given these changes, I believe forking the library under a separate name is the best approach.

Thanks regards